### PR TITLE
Allow `$import`s in type fields

### DIFF
--- a/sbpack/schemadef.py
+++ b/sbpack/schemadef.py
@@ -7,6 +7,7 @@ Types can refer to other types in the file
 Names can not clash across files (This seems arbitrary and we allow that for packing)
 Only records and arrays can be defined (https://github.com/common-workflow-language/cwl-v1.2/pull/14)
 """
+#  Copyright (c) 2023 Genomics plc
 #  Copyright (c) 2021 Michael R. Crusoe
 #  Copyright (c) 2020 Seven Bridges. See LICENSE
 
@@ -169,6 +170,13 @@ def _inline_type(v, base_url, user_defined_types):
         return [_inline_type(_v, base_url, user_defined_types) for _v in v]
 
     elif isinstance(v, dict):
+        if v.get("$import") is not None:
+            imported_type, import_base_url = sbpack.lib.load_linked_file(
+                base_url, v["$import"], is_import=True
+            )
+
+            return _inline_type(imported_type, import_base_url, user_defined_types)
+
         _type = v.get("type")
         if _type is None:
             raise sbpack.lib.MissingTypeName(

--- a/tests/test_packing.py
+++ b/tests/test_packing.py
@@ -108,5 +108,4 @@ def test_already_packed_graph():
 
 def test_import_in_type():
     cwl = pack("workflows/import-in-type.cwl")
-    print(cwl)
     assert cwl["inputs"][0]["type"] == ["File", "Directory"]

--- a/tests/test_packing.py
+++ b/tests/test_packing.py
@@ -105,3 +105,8 @@ def test_already_packed_graph():
     assert "outputs" not in cwl
     assert "$graph" in cwl
     assert "requirements" not in cwl
+
+def test_import_in_type():
+    cwl = pack("workflows/import-in-type.cwl")
+    print(cwl)
+    assert cwl["inputs"][0]["type"] == ["File", "Directory"]

--- a/tests/workflows/import-in-type.cwl
+++ b/tests/workflows/import-in-type.cwl
@@ -1,0 +1,19 @@
+#!/usr/bin/env cwl-runner
+
+class: CommandLineTool
+cwlVersion: v1.2
+
+inputs:
+ file1:
+  type:
+    $import: type-import.yaml
+
+outputs:
+  output:
+    type: File
+    outputBinding: { glob: output }
+
+baseCommand: [wc, -l]
+
+stdin: $(inputs.file1.path)
+stdout: output

--- a/tests/workflows/type-import.yaml
+++ b/tests/workflows/type-import.yaml
@@ -1,0 +1,2 @@
+- File
+- Directory


### PR DESCRIPTION
Fixes https://github.com/rabix/sbpack/issues/66.