### PR TITLE
Feature/tower yml support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/build/
+/dist/
+/sbpack.egg-info/
+/.idea/

--- a/sbpack/noncwl/Readme.md
+++ b/sbpack/noncwl/Readme.md
@@ -84,7 +84,7 @@ optional arguments:
                         Additional input schema files in CWL format.
   --revision-note REVISION_NOTE [REVISION_NOTE ...]
                         Revision note to be placed in the CWL schema if the app is uploaded to the sbg platform.
-  --manual-validation   You will have to provide validation for all 'string' type inputs if are string (s), file (f), directory (d), list of file (lf), or list of directory (ld) type inputs.
+  --manual-validation   You will have to provide validation for all 'string' type inputs if are string (str), file (file), directory (dir), list of file (files), or list of directory (dirs) type inputs.
 
 ```
 ### Example

--- a/sbpack/noncwl/nextflow.py
+++ b/sbpack/noncwl/nextflow.py
@@ -20,6 +20,7 @@ from sbpack.noncwl.utils import (
     GENERIC_FILE_ARRAY_INPUT,
     GENERIC_OUTPUT_DIRECTORY,
     WRAPPER_REQUIREMENTS,
+    SKIP_NEXTFLOW_TOWER_KEYS,
 )
 
 logger = logging.getLogger(__name__)
@@ -332,6 +333,12 @@ class SBNextflowWrapper:
         yml_schema = ruamel.yaml.safe_load(yml_file)
 
         for key, value in yml_schema.items():
+            # Tower yml file can use "tower" key in the yml file to designate
+            # some of the configurations tower uses. Since these are not output
+            # definitions, we skip these.
+            if key in SKIP_NEXTFLOW_TOWER_KEYS and \
+                    yml_file == 'tower.yml':
+                continue
             outputs.append(
                 self.make_output_type(key, value)
             )
@@ -493,8 +500,8 @@ def main():
         "--manual-validation", required=False, action="store_true",
         default=False,
         help="You will have to provide validation for all 'string' type inputs"
-             " if are string (s), file (f), directory (d), list of file (lf),"
-             " or list of directory (ld) type inputs.",
+             " if are string (str), file (file), directory (dir), list of file"
+             " (files), or list of directory (dirs) type inputs.",
     )
 
     args = parser.parse_args()

--- a/sbpack/noncwl/utils.py
+++ b/sbpack/noncwl/utils.py
@@ -47,6 +47,12 @@ WRAPPER_REQUIREMENTS = [
 ]
 
 
+SKIP_NEXTFLOW_TOWER_KEYS = [
+    'tower',
+    'mail',
+]
+
+
 def validate_inputs(inputs):
     types = {
         'str': 'string',
@@ -104,7 +110,7 @@ def zip_and_push_to_sb(api, workflow_path, project_id, folder_name):
     for packages on SevenBridges Platform. Delete local .zip file.
     """
 
-    basename = os.path.basename(workflow_path) + '_' + \
+    basename = os.path.basename(os.path.abspath(workflow_path)) + '_' + \
                time.strftime("%Y%m%d-%H%M%S")
 
     zip_path = os.path.join(os.path.dirname(workflow_path), basename + '.zip')


### PR DESCRIPTION
Fixed issue with "." being provided as --workflow-path. This caused the name of the archive created by sbpack_nf to start with ".", which in turn caused error when run on sb platform.
Excluded keywords reserved for nf tower configuration from outputs when tower.yml is used to generate output ports.